### PR TITLE
Initialize Spring Boot project with core domain entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# codex-opensearch
+# Book API
+
+Spring Boot 기반의 도서 정보 관리 API 서버 초기 프로젝트입니다. 현재 단계에서는 도메인 엔티티 설계와 기본적인 빌드 구성을 포함하고 있습니다.
+
+## 주요 구성 요소
+- Spring Boot 3.x (Web, Data JPA, Validation, Actuator)
+- PostgreSQL 드라이버 (런타임)
+- Gradle 빌드 스크립트
+
+## 패키지 구조
+```
+src/main/java/com/example/bookapi
+├── BookApiApplication.java
+├── common/
+│   └── AuditableEntity.java
+└── entity/
+    ├── enums/
+    │   ├── AssetType.java
+    │   ├── AvailabilityStatus.java
+    │   ├── BookFormat.java
+    │   ├── BookRelationType.java
+    │   └── ReviewStatus.java
+    ├── Author.java
+    ├── Book.java
+    ├── BookAsset.java
+    ├── BookAuthor.java
+    ├── BookAvailability.java
+    ├── BookCategory.java
+    ├── BookPrice.java
+    ├── BookRatingSummary.java
+    ├── BookReview.java
+    ├── Category.java
+    ├── Publisher.java
+    ├── RelatedBook.java
+    └── Series.java
+```
+
+## 다음 단계 아이디어
+- JPA 엔티티 간 연관관계를 활용한 CRUD 서비스 및 REST 컨트롤러 구현
+- Flyway/Liquibase 기반 스키마 관리
+- OpenSearch 연동 구성 및 색인 도큐먼트 설계

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.2.5'
+    id 'io.spring.dependency-management' version '1.1.4'
+}
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = '17'
+
+defaultTasks 'build'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    runtimeOnly 'org.postgresql:postgresql'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+rootProject.name = 'book-api'

--- a/src/main/java/com/example/bookapi/BookApiApplication.java
+++ b/src/main/java/com/example/bookapi/BookApiApplication.java
@@ -1,0 +1,12 @@
+package com.example.bookapi;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BookApiApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(BookApiApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/bookapi/common/AuditableEntity.java
+++ b/src/main/java/com/example/bookapi/common/AuditableEntity.java
@@ -1,0 +1,41 @@
+package com.example.bookapi.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import java.time.OffsetDateTime;
+
+@MappedSuperclass
+public abstract class AuditableEntity {
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        OffsetDateTime now = OffsetDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = OffsetDateTime.now();
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public OffsetDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(OffsetDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/example/bookapi/entity/Author.java
+++ b/src/main/java/com/example/bookapi/entity/Author.java
@@ -1,0 +1,95 @@
+package com.example.bookapi.entity;
+
+import com.example.bookapi.common.AuditableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "authors")
+public class Author extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 200)
+    private String name;
+
+    @Column(name = "name_kana", length = 200)
+    private String nameKana;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(length = 100)
+    private String role;
+
+    @Column(name = "profile_image_url", length = 500)
+    private String profileImageUrl;
+
+    @OneToMany(mappedBy = "author")
+    private List<BookAuthor> books = new ArrayList<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getNameKana() {
+        return nameKana;
+    }
+
+    public void setNameKana(String nameKana) {
+        this.nameKana = nameKana;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    public String getProfileImageUrl() {
+        return profileImageUrl;
+    }
+
+    public void setProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public List<BookAuthor> getBooks() {
+        return books;
+    }
+
+    public void setBooks(List<BookAuthor> books) {
+        this.books = books;
+    }
+}

--- a/src/main/java/com/example/bookapi/entity/Book.java
+++ b/src/main/java/com/example/bookapi/entity/Book.java
@@ -1,0 +1,326 @@
+package com.example.bookapi.entity;
+
+import com.example.bookapi.common.AuditableEntity;
+import com.example.bookapi.entity.enums.BookFormat;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "books")
+public class Book extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 300)
+    private String title;
+
+    @Column(length = 300)
+    private String subtitle;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "table_of_contents", columnDefinition = "TEXT")
+    private String tableOfContents;
+
+    @Column(length = 20, unique = true)
+    private String isbn13;
+
+    @Column(length = 20, unique = true)
+    private String isbn10;
+
+    @Column(name = "other_identifiers", columnDefinition = "TEXT")
+    private String otherIdentifiers;
+
+    @Column(length = 100)
+    private String edition;
+
+    private LocalDate publicationDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 50)
+    private BookFormat format;
+
+    @Column(length = 100)
+    private String language;
+
+    @Column(length = 200)
+    private String dimensions;
+
+    @Column(precision = 10, scale = 2)
+    private BigDecimal weight;
+
+    private Integer pageCount;
+
+    @Column(name = "publisher_note", columnDefinition = "TEXT")
+    private String publisherNote;
+
+    @Column(name = "inventory_note", columnDefinition = "TEXT")
+    private String inventoryNote;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "publisher_id")
+    private Publisher publisher;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "series_id")
+    private Series series;
+
+    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BookAuthor> authors = new ArrayList<>();
+
+    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BookCategory> categories = new ArrayList<>();
+
+    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BookPrice> prices = new ArrayList<>();
+
+    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BookAvailability> availabilities = new ArrayList<>();
+
+    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BookAsset> assets = new ArrayList<>();
+
+    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BookReview> reviews = new ArrayList<>();
+
+    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RelatedBook> relatedBooks = new ArrayList<>();
+
+    @OneToOne(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private BookRatingSummary ratingSummary;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getSubtitle() {
+        return subtitle;
+    }
+
+    public void setSubtitle(String subtitle) {
+        this.subtitle = subtitle;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getTableOfContents() {
+        return tableOfContents;
+    }
+
+    public void setTableOfContents(String tableOfContents) {
+        this.tableOfContents = tableOfContents;
+    }
+
+    public String getIsbn13() {
+        return isbn13;
+    }
+
+    public void setIsbn13(String isbn13) {
+        this.isbn13 = isbn13;
+    }
+
+    public String getIsbn10() {
+        return isbn10;
+    }
+
+    public void setIsbn10(String isbn10) {
+        this.isbn10 = isbn10;
+    }
+
+    public String getOtherIdentifiers() {
+        return otherIdentifiers;
+    }
+
+    public void setOtherIdentifiers(String otherIdentifiers) {
+        this.otherIdentifiers = otherIdentifiers;
+    }
+
+    public String getEdition() {
+        return edition;
+    }
+
+    public void setEdition(String edition) {
+        this.edition = edition;
+    }
+
+    public LocalDate getPublicationDate() {
+        return publicationDate;
+    }
+
+    public void setPublicationDate(LocalDate publicationDate) {
+        this.publicationDate = publicationDate;
+    }
+
+    public BookFormat getFormat() {
+        return format;
+    }
+
+    public void setFormat(BookFormat format) {
+        this.format = format;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    public String getDimensions() {
+        return dimensions;
+    }
+
+    public void setDimensions(String dimensions) {
+        this.dimensions = dimensions;
+    }
+
+    public BigDecimal getWeight() {
+        return weight;
+    }
+
+    public void setWeight(BigDecimal weight) {
+        this.weight = weight;
+    }
+
+    public Integer getPageCount() {
+        return pageCount;
+    }
+
+    public void setPageCount(Integer pageCount) {
+        this.pageCount = pageCount;
+    }
+
+    public String getPublisherNote() {
+        return publisherNote;
+    }
+
+    public void setPublisherNote(String publisherNote) {
+        this.publisherNote = publisherNote;
+    }
+
+    public String getInventoryNote() {
+        return inventoryNote;
+    }
+
+    public void setInventoryNote(String inventoryNote) {
+        this.inventoryNote = inventoryNote;
+    }
+
+    public Publisher getPublisher() {
+        return publisher;
+    }
+
+    public void setPublisher(Publisher publisher) {
+        this.publisher = publisher;
+    }
+
+    public Series getSeries() {
+        return series;
+    }
+
+    public void setSeries(Series series) {
+        this.series = series;
+    }
+
+    public List<BookAuthor> getAuthors() {
+        return authors;
+    }
+
+    public void setAuthors(List<BookAuthor> authors) {
+        this.authors = authors;
+    }
+
+    public List<BookCategory> getCategories() {
+        return categories;
+    }
+
+    public void setCategories(List<BookCategory> categories) {
+        this.categories = categories;
+    }
+
+    public List<BookPrice> getPrices() {
+        return prices;
+    }
+
+    public void setPrices(List<BookPrice> prices) {
+        this.prices = prices;
+    }
+
+    public List<BookAvailability> getAvailabilities() {
+        return availabilities;
+    }
+
+    public void setAvailabilities(List<BookAvailability> availabilities) {
+        this.availabilities = availabilities;
+    }
+
+    public List<BookAsset> getAssets() {
+        return assets;
+    }
+
+    public void setAssets(List<BookAsset> assets) {
+        this.assets = assets;
+    }
+
+    public List<BookReview> getReviews() {
+        return reviews;
+    }
+
+    public void setReviews(List<BookReview> reviews) {
+        this.reviews = reviews;
+    }
+
+    public List<RelatedBook> getRelatedBooks() {
+        return relatedBooks;
+    }
+
+    public void setRelatedBooks(List<RelatedBook> relatedBooks) {
+        this.relatedBooks = relatedBooks;
+    }
+
+    public BookRatingSummary getRatingSummary() {
+        return ratingSummary;
+    }
+
+    public void setRatingSummary(BookRatingSummary ratingSummary) {
+        this.ratingSummary = ratingSummary;
+    }
+}

--- a/src/main/java/com/example/bookapi/entity/BookAsset.java
+++ b/src/main/java/com/example/bookapi/entity/BookAsset.java
@@ -1,0 +1,89 @@
+package com.example.bookapi.entity;
+
+import com.example.bookapi.common.AuditableEntity;
+import com.example.bookapi.entity.enums.AssetType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "book_assets")
+public class BookAsset extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id", nullable = false)
+    private Book book;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 30, nullable = false)
+    private AssetType type;
+
+    @Column(nullable = false, length = 500)
+    private String url;
+
+    @Column(name = "thumbnail_url", length = 500)
+    private String thumbnailUrl;
+
+    @Column(name = "sequence_no")
+    private Integer sequence;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Book getBook() {
+        return book;
+    }
+
+    public void setBook(Book book) {
+        this.book = book;
+    }
+
+    public AssetType getType() {
+        return type;
+    }
+
+    public void setType(AssetType type) {
+        this.type = type;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getThumbnailUrl() {
+        return thumbnailUrl;
+    }
+
+    public void setThumbnailUrl(String thumbnailUrl) {
+        this.thumbnailUrl = thumbnailUrl;
+    }
+
+    public Integer getSequence() {
+        return sequence;
+    }
+
+    public void setSequence(Integer sequence) {
+        this.sequence = sequence;
+    }
+}

--- a/src/main/java/com/example/bookapi/entity/BookAuthor.java
+++ b/src/main/java/com/example/bookapi/entity/BookAuthor.java
@@ -1,0 +1,75 @@
+package com.example.bookapi.entity;
+
+import com.example.bookapi.common.AuditableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "book_authors")
+public class BookAuthor extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id", nullable = false)
+    private Book book;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private Author author;
+
+    @Column(name = "author_order")
+    private Integer authorOrder;
+
+    @Column(length = 100)
+    private String role;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Book getBook() {
+        return book;
+    }
+
+    public void setBook(Book book) {
+        this.book = book;
+    }
+
+    public Author getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(Author author) {
+        this.author = author;
+    }
+
+    public Integer getAuthorOrder() {
+        return authorOrder;
+    }
+
+    public void setAuthorOrder(Integer authorOrder) {
+        this.authorOrder = authorOrder;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+}

--- a/src/main/java/com/example/bookapi/entity/BookAvailability.java
+++ b/src/main/java/com/example/bookapi/entity/BookAvailability.java
@@ -1,0 +1,134 @@
+package com.example.bookapi.entity;
+
+import com.example.bookapi.common.AuditableEntity;
+import com.example.bookapi.entity.enums.AvailabilityStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "book_availabilities")
+public class BookAvailability extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id", nullable = false)
+    private Book book;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 30, nullable = false)
+    private AvailabilityStatus status;
+
+    @Column(name = "stock_quantity")
+    private Integer stockQuantity;
+
+    @Column(name = "safety_stock")
+    private Integer safetyStock;
+
+    @Column(name = "lead_time")
+    private Integer leadTime;
+
+    @Column(name = "expected_restock_date")
+    private OffsetDateTime expectedRestockDate;
+
+    @Column(length = 100)
+    private String channel;
+
+    @Column(name = "effective_from", nullable = false)
+    private OffsetDateTime effectiveFrom;
+
+    @Column(name = "effective_to")
+    private OffsetDateTime effectiveTo;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Book getBook() {
+        return book;
+    }
+
+    public void setBook(Book book) {
+        this.book = book;
+    }
+
+    public AvailabilityStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(AvailabilityStatus status) {
+        this.status = status;
+    }
+
+    public Integer getStockQuantity() {
+        return stockQuantity;
+    }
+
+    public void setStockQuantity(Integer stockQuantity) {
+        this.stockQuantity = stockQuantity;
+    }
+
+    public Integer getSafetyStock() {
+        return safetyStock;
+    }
+
+    public void setSafetyStock(Integer safetyStock) {
+        this.safetyStock = safetyStock;
+    }
+
+    public Integer getLeadTime() {
+        return leadTime;
+    }
+
+    public void setLeadTime(Integer leadTime) {
+        this.leadTime = leadTime;
+    }
+
+    public OffsetDateTime getExpectedRestockDate() {
+        return expectedRestockDate;
+    }
+
+    public void setExpectedRestockDate(OffsetDateTime expectedRestockDate) {
+        this.expectedRestockDate = expectedRestockDate;
+    }
+
+    public String getChannel() {
+        return channel;
+    }
+
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+
+    public OffsetDateTime getEffectiveFrom() {
+        return effectiveFrom;
+    }
+
+    public void setEffectiveFrom(OffsetDateTime effectiveFrom) {
+        this.effectiveFrom = effectiveFrom;
+    }
+
+    public OffsetDateTime getEffectiveTo() {
+        return effectiveTo;
+    }
+
+    public void setEffectiveTo(OffsetDateTime effectiveTo) {
+        this.effectiveTo = effectiveTo;
+    }
+}

--- a/src/main/java/com/example/bookapi/entity/BookCategory.java
+++ b/src/main/java/com/example/bookapi/entity/BookCategory.java
@@ -1,0 +1,75 @@
+package com.example.bookapi.entity;
+
+import com.example.bookapi.common.AuditableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "book_categories")
+public class BookCategory extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id", nullable = false)
+    private Book book;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @Column(name = "is_primary", nullable = false)
+    private boolean primary;
+
+    @Column(name = "sort_order")
+    private Integer sortOrder;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Book getBook() {
+        return book;
+    }
+
+    public void setBook(Book book) {
+        this.book = book;
+    }
+
+    public Category getCategory() {
+        return category;
+    }
+
+    public void setCategory(Category category) {
+        this.category = category;
+    }
+
+    public boolean isPrimary() {
+        return primary;
+    }
+
+    public void setPrimary(boolean primary) {
+        this.primary = primary;
+    }
+
+    public Integer getSortOrder() {
+        return sortOrder;
+    }
+
+    public void setSortOrder(Integer sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+}

--- a/src/main/java/com/example/bookapi/entity/BookPrice.java
+++ b/src/main/java/com/example/bookapi/entity/BookPrice.java
@@ -1,0 +1,131 @@
+package com.example.bookapi.entity;
+
+import com.example.bookapi.common.AuditableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "book_prices")
+public class BookPrice extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id", nullable = false)
+    private Book book;
+
+    @Column(name = "list_price", precision = 12, scale = 2, nullable = false)
+    private BigDecimal listPrice;
+
+    @Column(name = "sale_price", precision = 12, scale = 2)
+    private BigDecimal salePrice;
+
+    @Column(name = "discount_rate", precision = 5, scale = 2)
+    private BigDecimal discountRate;
+
+    @Column(name = "points_accrued", precision = 12, scale = 2)
+    private BigDecimal pointsAccrued;
+
+    @Column(name = "coupon_discount", precision = 12, scale = 2)
+    private BigDecimal couponDiscount;
+
+    @Column(length = 3, nullable = false)
+    private String currency;
+
+    @Column(name = "effective_from", nullable = false)
+    private OffsetDateTime effectiveFrom;
+
+    @Column(name = "effective_to")
+    private OffsetDateTime effectiveTo;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Book getBook() {
+        return book;
+    }
+
+    public void setBook(Book book) {
+        this.book = book;
+    }
+
+    public BigDecimal getListPrice() {
+        return listPrice;
+    }
+
+    public void setListPrice(BigDecimal listPrice) {
+        this.listPrice = listPrice;
+    }
+
+    public BigDecimal getSalePrice() {
+        return salePrice;
+    }
+
+    public void setSalePrice(BigDecimal salePrice) {
+        this.salePrice = salePrice;
+    }
+
+    public BigDecimal getDiscountRate() {
+        return discountRate;
+    }
+
+    public void setDiscountRate(BigDecimal discountRate) {
+        this.discountRate = discountRate;
+    }
+
+    public BigDecimal getPointsAccrued() {
+        return pointsAccrued;
+    }
+
+    public void setPointsAccrued(BigDecimal pointsAccrued) {
+        this.pointsAccrued = pointsAccrued;
+    }
+
+    public BigDecimal getCouponDiscount() {
+        return couponDiscount;
+    }
+
+    public void setCouponDiscount(BigDecimal couponDiscount) {
+        this.couponDiscount = couponDiscount;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public OffsetDateTime getEffectiveFrom() {
+        return effectiveFrom;
+    }
+
+    public void setEffectiveFrom(OffsetDateTime effectiveFrom) {
+        this.effectiveFrom = effectiveFrom;
+    }
+
+    public OffsetDateTime getEffectiveTo() {
+        return effectiveTo;
+    }
+
+    public void setEffectiveTo(OffsetDateTime effectiveTo) {
+        this.effectiveTo = effectiveTo;
+    }
+}

--- a/src/main/java/com/example/bookapi/entity/BookRatingSummary.java
+++ b/src/main/java/com/example/bookapi/entity/BookRatingSummary.java
@@ -1,0 +1,75 @@
+package com.example.bookapi.entity;
+
+import com.example.bookapi.common.AuditableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "book_rating_summaries")
+public class BookRatingSummary extends AuditableEntity {
+
+    @Id
+    @Column(name = "book_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId
+    @JoinColumn(name = "book_id")
+    private Book book;
+
+    @Column(name = "average_rating", precision = 3, scale = 2)
+    private BigDecimal averageRating;
+
+    @Column(name = "review_count")
+    private Long reviewCount;
+
+    @Column(name = "rating_distribution", columnDefinition = "TEXT")
+    private String ratingDistribution;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Book getBook() {
+        return book;
+    }
+
+    public void setBook(Book book) {
+        this.book = book;
+    }
+
+    public BigDecimal getAverageRating() {
+        return averageRating;
+    }
+
+    public void setAverageRating(BigDecimal averageRating) {
+        this.averageRating = averageRating;
+    }
+
+    public Long getReviewCount() {
+        return reviewCount;
+    }
+
+    public void setReviewCount(Long reviewCount) {
+        this.reviewCount = reviewCount;
+    }
+
+    public String getRatingDistribution() {
+        return ratingDistribution;
+    }
+
+    public void setRatingDistribution(String ratingDistribution) {
+        this.ratingDistribution = ratingDistribution;
+    }
+}

--- a/src/main/java/com/example/bookapi/entity/BookReview.java
+++ b/src/main/java/com/example/bookapi/entity/BookReview.java
@@ -1,0 +1,110 @@
+package com.example.bookapi.entity;
+
+import com.example.bookapi.common.AuditableEntity;
+import com.example.bookapi.entity.enums.ReviewStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "book_reviews")
+public class BookReview extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id", nullable = false)
+    private Book book;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private int rating;
+
+    @Column(length = 200)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    private int likes;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    private ReviewStatus status = ReviewStatus.PENDING;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Book getBook() {
+        return book;
+    }
+
+    public void setBook(Book book) {
+        this.book = book;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public int getRating() {
+        return rating;
+    }
+
+    public void setRating(int rating) {
+        this.rating = rating;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public int getLikes() {
+        return likes;
+    }
+
+    public void setLikes(int likes) {
+        this.likes = likes;
+    }
+
+    public ReviewStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(ReviewStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/example/bookapi/entity/Category.java
+++ b/src/main/java/com/example/bookapi/entity/Category.java
@@ -1,0 +1,99 @@
+package com.example.bookapi.entity;
+
+import com.example.bookapi.common.AuditableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "categories")
+public class Category extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50, unique = true)
+    private String code;
+
+    @Column(nullable = false, length = 200)
+    private String name;
+
+    @Column(nullable = false, length = 10)
+    private String level;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Category parent;
+
+    @OneToMany(mappedBy = "parent")
+    private List<Category> children = new ArrayList<>();
+
+    @OneToMany(mappedBy = "category")
+    private List<BookCategory> books = new ArrayList<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getLevel() {
+        return level;
+    }
+
+    public void setLevel(String level) {
+        this.level = level;
+    }
+
+    public Category getParent() {
+        return parent;
+    }
+
+    public void setParent(Category parent) {
+        this.parent = parent;
+    }
+
+    public List<Category> getChildren() {
+        return children;
+    }
+
+    public void setChildren(List<Category> children) {
+        this.children = children;
+    }
+
+    public List<BookCategory> getBooks() {
+        return books;
+    }
+
+    public void setBooks(List<BookCategory> books) {
+        this.books = books;
+    }
+}

--- a/src/main/java/com/example/bookapi/entity/Publisher.java
+++ b/src/main/java/com/example/bookapi/entity/Publisher.java
@@ -1,0 +1,84 @@
+package com.example.bookapi.entity;
+
+import com.example.bookapi.common.AuditableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "publishers")
+public class Publisher extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 200)
+    private String name;
+
+    @Column(length = 200)
+    private String imprint;
+
+    @Column(length = 500)
+    private String homepage;
+
+    @Column(length = 500)
+    private String contact;
+
+    @OneToMany(mappedBy = "publisher")
+    private List<Book> books = new ArrayList<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getImprint() {
+        return imprint;
+    }
+
+    public void setImprint(String imprint) {
+        this.imprint = imprint;
+    }
+
+    public String getHomepage() {
+        return homepage;
+    }
+
+    public void setHomepage(String homepage) {
+        this.homepage = homepage;
+    }
+
+    public String getContact() {
+        return contact;
+    }
+
+    public void setContact(String contact) {
+        this.contact = contact;
+    }
+
+    public List<Book> getBooks() {
+        return books;
+    }
+
+    public void setBooks(List<Book> books) {
+        this.books = books;
+    }
+}

--- a/src/main/java/com/example/bookapi/entity/RelatedBook.java
+++ b/src/main/java/com/example/bookapi/entity/RelatedBook.java
@@ -1,0 +1,79 @@
+package com.example.bookapi.entity;
+
+import com.example.bookapi.common.AuditableEntity;
+import com.example.bookapi.entity.enums.BookRelationType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "related_books")
+public class RelatedBook extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id", nullable = false)
+    private Book book;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "related_book_id", nullable = false)
+    private Book relatedBook;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "relation_type", length = 30, nullable = false)
+    private BookRelationType relationType;
+
+    @Column(name = "sequence_no")
+    private Integer sequence;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Book getBook() {
+        return book;
+    }
+
+    public void setBook(Book book) {
+        this.book = book;
+    }
+
+    public Book getRelatedBook() {
+        return relatedBook;
+    }
+
+    public void setRelatedBook(Book relatedBook) {
+        this.relatedBook = relatedBook;
+    }
+
+    public BookRelationType getRelationType() {
+        return relationType;
+    }
+
+    public void setRelationType(BookRelationType relationType) {
+        this.relationType = relationType;
+    }
+
+    public Integer getSequence() {
+        return sequence;
+    }
+
+    public void setSequence(Integer sequence) {
+        this.sequence = sequence;
+    }
+}

--- a/src/main/java/com/example/bookapi/entity/Series.java
+++ b/src/main/java/com/example/bookapi/entity/Series.java
@@ -1,0 +1,73 @@
+package com.example.bookapi.entity;
+
+import com.example.bookapi.common.AuditableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "series")
+public class Series extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 200)
+    private String name;
+
+    @Column(name = "volume_numbering", length = 100)
+    private String volumeNumbering;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @OneToMany(mappedBy = "series")
+    private List<Book> books = new ArrayList<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getVolumeNumbering() {
+        return volumeNumbering;
+    }
+
+    public void setVolumeNumbering(String volumeNumbering) {
+        this.volumeNumbering = volumeNumbering;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public List<Book> getBooks() {
+        return books;
+    }
+
+    public void setBooks(List<Book> books) {
+        this.books = books;
+    }
+}

--- a/src/main/java/com/example/bookapi/entity/enums/AssetType.java
+++ b/src/main/java/com/example/bookapi/entity/enums/AssetType.java
@@ -1,0 +1,8 @@
+package com.example.bookapi.entity.enums;
+
+public enum AssetType {
+    COVER,
+    PREVIEW,
+    SAMPLE_PAGE,
+    MEDIA
+}

--- a/src/main/java/com/example/bookapi/entity/enums/AvailabilityStatus.java
+++ b/src/main/java/com/example/bookapi/entity/enums/AvailabilityStatus.java
@@ -1,0 +1,10 @@
+package com.example.bookapi.entity.enums;
+
+public enum AvailabilityStatus {
+    ON_SALE,
+    PREORDER,
+    OUT_OF_STOCK,
+    DISCONTINUED,
+    POD,
+    BACKORDER
+}

--- a/src/main/java/com/example/bookapi/entity/enums/BookFormat.java
+++ b/src/main/java/com/example/bookapi/entity/enums/BookFormat.java
@@ -1,0 +1,10 @@
+package com.example.bookapi.entity.enums;
+
+public enum BookFormat {
+    HARDCOVER,
+    PAPERBACK,
+    EBOOK,
+    AUDIOBOOK,
+    MAGAZINE,
+    OTHER
+}

--- a/src/main/java/com/example/bookapi/entity/enums/BookRelationType.java
+++ b/src/main/java/com/example/bookapi/entity/enums/BookRelationType.java
@@ -1,0 +1,10 @@
+package com.example.bookapi.entity.enums;
+
+public enum BookRelationType {
+    RECOMMENDED,
+    SERIES,
+    SET,
+    SIMILAR,
+    AUTHOR_OTHER_WORK,
+    SAME_PUBLISHER
+}

--- a/src/main/java/com/example/bookapi/entity/enums/ReviewStatus.java
+++ b/src/main/java/com/example/bookapi/entity/enums/ReviewStatus.java
@@ -1,0 +1,8 @@
+package com.example.bookapi.entity.enums;
+
+public enum ReviewStatus {
+    PENDING,
+    PUBLISHED,
+    HIDDEN,
+    DELETED
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,22 @@
+spring:
+  application:
+    name: book-api
+  datasource:
+    url: jdbc:postgresql://localhost:5432/bookdb
+    username: book
+    password: book
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: true
+    show-sql: false
+server:
+  port: 8080
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info


### PR DESCRIPTION
## Summary
- set up a Gradle-based Spring Boot project skeleton with the application entry point and foundational build configuration
- add comprehensive JPA entities and supporting enums covering books, contributors, classifications, commercial attributes, and relationships
- document the package layout and default application configuration for the new service

## Testing
- not run (Gradle wrapper download requires external network access unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dacf56f96c8323998f3d09e2afe7b0