### PR TITLE
feat: implement book registration API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/src/main/java/com/example/bookapi/book/adapter/in/web/BookController.java
+++ b/src/main/java/com/example/bookapi/book/adapter/in/web/BookController.java
@@ -1,0 +1,83 @@
+package com.example.bookapi.book.adapter.in.web;
+
+import com.example.bookapi.book.adapter.in.web.dto.RegisterBookRequest;
+import com.example.bookapi.book.adapter.in.web.dto.RegisterBookResponse;
+import com.example.bookapi.book.application.port.in.BookRegistrationResult;
+import com.example.bookapi.book.application.port.in.RegisterBookCommand;
+import com.example.bookapi.book.application.port.in.RegisterBookUseCase;
+import com.example.bookapi.entity.enums.BookFormat;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.Locale;
+import java.util.Optional;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@RestController
+@RequestMapping("/api/books")
+public class BookController {
+
+    private final RegisterBookUseCase registerBookUseCase;
+
+    public BookController(RegisterBookUseCase registerBookUseCase) {
+        this.registerBookUseCase = registerBookUseCase;
+    }
+
+    @PostMapping
+    public ResponseEntity<RegisterBookResponse> register(@Valid @RequestBody RegisterBookRequest request) {
+        RegisterBookCommand command = toCommand(request);
+        BookRegistrationResult result = registerBookUseCase.register(command);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(result.bookId())
+                .toUri();
+
+        return ResponseEntity
+                .created(location)
+                .body(new RegisterBookResponse(result.bookId()));
+    }
+
+    private RegisterBookCommand toCommand(RegisterBookRequest request) {
+        return new RegisterBookCommand(
+                request.title(),
+                request.subtitle(),
+                request.description(),
+                request.tableOfContents(),
+                request.isbn13(),
+                request.isbn10(),
+                request.otherIdentifiers(),
+                request.edition(),
+                request.publicationDate(),
+                parseFormat(request.format()),
+                request.language(),
+                request.dimensions(),
+                request.weight(),
+                request.pageCount(),
+                request.publisherNote(),
+                request.inventoryNote()
+        );
+    }
+
+    private BookFormat parseFormat(String format) {
+        return Optional.ofNullable(format)
+                .map(value -> {
+                    try {
+                        return BookFormat.valueOf(value.toUpperCase(Locale.ROOT));
+                    } catch (IllegalArgumentException ex) {
+                        throw new ResponseStatusException(
+                                HttpStatus.BAD_REQUEST,
+                                "Invalid book format: " + value
+                        );
+                    }
+                })
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/example/bookapi/book/adapter/in/web/dto/RegisterBookRequest.java
+++ b/src/main/java/com/example/bookapi/book/adapter/in/web/dto/RegisterBookRequest.java
@@ -1,0 +1,35 @@
+package com.example.bookapi.book.adapter.in.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record RegisterBookRequest(
+        @NotBlank(message = "title is required")
+        @Size(max = 300)
+        String title,
+        @Size(max = 300)
+        String subtitle,
+        String description,
+        String tableOfContents,
+        @Size(max = 20)
+        String isbn13,
+        @Size(max = 20)
+        String isbn10,
+        String otherIdentifiers,
+        @Size(max = 100)
+        String edition,
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate publicationDate,
+        String format,
+        @Size(max = 100)
+        String language,
+        String dimensions,
+        BigDecimal weight,
+        Integer pageCount,
+        String publisherNote,
+        String inventoryNote
+) {
+}

--- a/src/main/java/com/example/bookapi/book/adapter/in/web/dto/RegisterBookResponse.java
+++ b/src/main/java/com/example/bookapi/book/adapter/in/web/dto/RegisterBookResponse.java
@@ -1,0 +1,4 @@
+package com.example.bookapi.book.adapter.in.web.dto;
+
+public record RegisterBookResponse(Long id) {
+}

--- a/src/main/java/com/example/bookapi/book/adapter/out/persistence/BookJpaRepository.java
+++ b/src/main/java/com/example/bookapi/book/adapter/out/persistence/BookJpaRepository.java
@@ -1,0 +1,7 @@
+package com.example.bookapi.book.adapter.out.persistence;
+
+import com.example.bookapi.entity.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookJpaRepository extends JpaRepository<Book, Long> {
+}

--- a/src/main/java/com/example/bookapi/book/adapter/out/persistence/BookPersistenceAdapter.java
+++ b/src/main/java/com/example/bookapi/book/adapter/out/persistence/BookPersistenceAdapter.java
@@ -1,0 +1,43 @@
+package com.example.bookapi.book.adapter.out.persistence;
+
+import com.example.bookapi.book.application.port.out.SaveBookPort;
+import com.example.bookapi.book.domain.BookRegistration;
+import com.example.bookapi.entity.Book;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BookPersistenceAdapter implements SaveBookPort {
+
+    private final BookJpaRepository bookJpaRepository;
+
+    public BookPersistenceAdapter(BookJpaRepository bookJpaRepository) {
+        this.bookJpaRepository = bookJpaRepository;
+    }
+
+    @Override
+    public Long save(BookRegistration registration) {
+        Book entity = mapToEntity(registration);
+        return bookJpaRepository.save(entity).getId();
+    }
+
+    private Book mapToEntity(BookRegistration registration) {
+        Book book = new Book();
+        book.setTitle(registration.title());
+        book.setSubtitle(registration.subtitle());
+        book.setDescription(registration.description());
+        book.setTableOfContents(registration.tableOfContents());
+        book.setIsbn13(registration.isbn13());
+        book.setIsbn10(registration.isbn10());
+        book.setOtherIdentifiers(registration.otherIdentifiers());
+        book.setEdition(registration.edition());
+        book.setPublicationDate(registration.publicationDate());
+        book.setFormat(registration.format());
+        book.setLanguage(registration.language());
+        book.setDimensions(registration.dimensions());
+        book.setWeight(registration.weight());
+        book.setPageCount(registration.pageCount());
+        book.setPublisherNote(registration.publisherNote());
+        book.setInventoryNote(registration.inventoryNote());
+        return book;
+    }
+}

--- a/src/main/java/com/example/bookapi/book/application/port/in/BookRegistrationResult.java
+++ b/src/main/java/com/example/bookapi/book/application/port/in/BookRegistrationResult.java
@@ -1,0 +1,4 @@
+package com.example.bookapi.book.application.port.in;
+
+public record BookRegistrationResult(Long bookId) {
+}

--- a/src/main/java/com/example/bookapi/book/application/port/in/RegisterBookCommand.java
+++ b/src/main/java/com/example/bookapi/book/application/port/in/RegisterBookCommand.java
@@ -1,0 +1,52 @@
+package com.example.bookapi.book.application.port.in;
+
+import com.example.bookapi.book.domain.BookRegistration;
+import com.example.bookapi.entity.enums.BookFormat;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Objects;
+
+public record RegisterBookCommand(
+        String title,
+        String subtitle,
+        String description,
+        String tableOfContents,
+        String isbn13,
+        String isbn10,
+        String otherIdentifiers,
+        String edition,
+        LocalDate publicationDate,
+        BookFormat format,
+        String language,
+        String dimensions,
+        BigDecimal weight,
+        Integer pageCount,
+        String publisherNote,
+        String inventoryNote
+) {
+
+    public RegisterBookCommand {
+        Objects.requireNonNull(title, "title must not be null");
+    }
+
+    public BookRegistration toBookRegistration() {
+        return new BookRegistration(
+                title,
+                subtitle,
+                description,
+                tableOfContents,
+                isbn13,
+                isbn10,
+                otherIdentifiers,
+                edition,
+                publicationDate,
+                format,
+                language,
+                dimensions,
+                weight,
+                pageCount,
+                publisherNote,
+                inventoryNote
+        );
+    }
+}

--- a/src/main/java/com/example/bookapi/book/application/port/in/RegisterBookUseCase.java
+++ b/src/main/java/com/example/bookapi/book/application/port/in/RegisterBookUseCase.java
@@ -1,0 +1,6 @@
+package com.example.bookapi.book.application.port.in;
+
+public interface RegisterBookUseCase {
+
+    BookRegistrationResult register(RegisterBookCommand command);
+}

--- a/src/main/java/com/example/bookapi/book/application/port/out/SaveBookPort.java
+++ b/src/main/java/com/example/bookapi/book/application/port/out/SaveBookPort.java
@@ -1,0 +1,8 @@
+package com.example.bookapi.book.application.port.out;
+
+import com.example.bookapi.book.domain.BookRegistration;
+
+public interface SaveBookPort {
+
+    Long save(BookRegistration registration);
+}

--- a/src/main/java/com/example/bookapi/book/application/service/RegisterBookService.java
+++ b/src/main/java/com/example/bookapi/book/application/service/RegisterBookService.java
@@ -1,0 +1,27 @@
+package com.example.bookapi.book.application.service;
+
+import com.example.bookapi.book.application.port.in.BookRegistrationResult;
+import com.example.bookapi.book.application.port.in.RegisterBookCommand;
+import com.example.bookapi.book.application.port.in.RegisterBookUseCase;
+import com.example.bookapi.book.application.port.out.SaveBookPort;
+import com.example.bookapi.book.domain.BookRegistration;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class RegisterBookService implements RegisterBookUseCase {
+
+    private final SaveBookPort saveBookPort;
+
+    public RegisterBookService(SaveBookPort saveBookPort) {
+        this.saveBookPort = saveBookPort;
+    }
+
+    @Override
+    public BookRegistrationResult register(RegisterBookCommand command) {
+        BookRegistration registration = command.toBookRegistration();
+        Long bookId = saveBookPort.save(registration);
+        return new BookRegistrationResult(bookId);
+    }
+}

--- a/src/main/java/com/example/bookapi/book/domain/BookRegistration.java
+++ b/src/main/java/com/example/bookapi/book/domain/BookRegistration.java
@@ -1,0 +1,30 @@
+package com.example.bookapi.book.domain;
+
+import com.example.bookapi.entity.enums.BookFormat;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Objects;
+
+public record BookRegistration(
+        String title,
+        String subtitle,
+        String description,
+        String tableOfContents,
+        String isbn13,
+        String isbn10,
+        String otherIdentifiers,
+        String edition,
+        LocalDate publicationDate,
+        BookFormat format,
+        String language,
+        String dimensions,
+        BigDecimal weight,
+        Integer pageCount,
+        String publisherNote,
+        String inventoryNote
+) {
+
+    public BookRegistration {
+        Objects.requireNonNull(title, "title must not be null");
+    }
+}


### PR DESCRIPTION
## Summary
- add clean architecture components for registering books
- expose POST /api/books endpoint with validation and response metadata
- persist book information via a JPA adapter and ignore build artifacts

## Testing
- gradle test

------
https://chatgpt.com/codex/tasks/task_e_68dbfd31b14c8323a25baea959f27215