### PR TITLE
Add OpenSearch indexing after book registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,12 @@ src/main/java/com/example/bookapi
     └── Series.java
 ```
 
+## OpenSearch 연동
+- `docker run -p 9200:9200 -e discovery.type=single-node -e OPENSEARCH_INITIAL_ADMIN_PASSWORD=admin --name opensearch opensearchproject/opensearch:2.11.0`과 같이 OpenSearch를 로컬에서 실행합니다. (테스트 용도로 보안을 비활성화하려면 `-e plugins.security.disabled=true` 옵션을 추가하고 비밀번호 설정을 제거합니다.)
+- `src/main/resources/application.yml`의 `opensearch` 섹션을 환경에 맞게 조정합니다.
+- 도서 등록 API가 성공하면 Spring `ApplicationEvent`가 발행되고, 커밋 이후 OpenSearch 인덱스(`books`)에 문서가 생성됩니다.
+
 ## 다음 단계 아이디어
 - JPA 엔티티 간 연관관계를 활용한 CRUD 서비스 및 REST 컨트롤러 구현
 - Flyway/Liquibase 기반 스키마 관리
-- OpenSearch 연동 구성 및 색인 도큐먼트 설계
+- 검색 조건/필터 API 구현 및 테스트 작성

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ defaultTasks 'build'
 
 repositories {
     mavenCentral()
+    maven { url 'https://aws.oss.sonatype.org/content/repositories/releases/' }
 }
 
 dependencies {
@@ -19,6 +20,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.opensearch.client:opensearch-java:2.11.0'
+    implementation 'org.opensearch.client:opensearch-rest-client:2.11.0'
+
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     runtimeOnly 'org.postgresql:postgresql'
 

--- a/src/main/java/com/example/bookapi/book/adapter/out/index/BookIndexingException.java
+++ b/src/main/java/com/example/bookapi/book/adapter/out/index/BookIndexingException.java
@@ -1,0 +1,8 @@
+package com.example.bookapi.book.adapter.out.index;
+
+public class BookIndexingException extends RuntimeException {
+
+    public BookIndexingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/example/bookapi/book/adapter/out/index/BookSearchDocument.java
+++ b/src/main/java/com/example/bookapi/book/adapter/out/index/BookSearchDocument.java
@@ -1,0 +1,26 @@
+package com.example.bookapi.book.adapter.out.index;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+public record BookSearchDocument(
+        Long id,
+        String title,
+        String subtitle,
+        String description,
+        String publisher,
+        List<String> authors,
+        LocalDate publicationDate,
+        String language,
+        List<String> categoryCodes,
+        List<String> categoryNames,
+        BigDecimal listPrice,
+        BigDecimal salePrice,
+        BigDecimal discountRate,
+        String availabilityStatus,
+        Integer stockQuantity,
+        Double averageRating,
+        Integer reviewCount
+) {
+}

--- a/src/main/java/com/example/bookapi/book/adapter/out/index/BookSearchDocumentMapper.java
+++ b/src/main/java/com/example/bookapi/book/adapter/out/index/BookSearchDocumentMapper.java
@@ -1,0 +1,99 @@
+package com.example.bookapi.book.adapter.out.index;
+
+import com.example.bookapi.entity.Book;
+import com.example.bookapi.entity.BookAuthor;
+import com.example.bookapi.entity.BookAvailability;
+import com.example.bookapi.entity.BookCategory;
+import com.example.bookapi.entity.BookPrice;
+import com.example.bookapi.entity.BookReview;
+import java.time.OffsetDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BookSearchDocumentMapper {
+
+    public BookSearchDocument map(Book book) {
+        BookPrice activePrice = selectActivePrice(book);
+        BookAvailability activeAvailability = selectActiveAvailability(book);
+
+        List<String> authors = book.getAuthors().stream()
+                .sorted(Comparator.comparing(BookAuthor::getAuthorOrder, Comparator.nullsLast(Integer::compareTo)))
+                .map(BookAuthor::getAuthor)
+                .filter(Objects::nonNull)
+                .map(author -> author.getName())
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        List<String> categoryCodes = book.getCategories().stream()
+                .map(BookCategory::getCategory)
+                .filter(Objects::nonNull)
+                .map(category -> category.getCode())
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        List<String> categoryNames = book.getCategories().stream()
+                .map(BookCategory::getCategory)
+                .filter(Objects::nonNull)
+                .map(category -> category.getName())
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        Double averageRating = book.getRatingSummary() != null && book.getRatingSummary().getAverageRating() != null
+                ? book.getRatingSummary().getAverageRating().doubleValue()
+                : null;
+        Integer reviewCount = book.getRatingSummary() != null && book.getRatingSummary().getReviewCount() != null
+                ? Math.toIntExact(book.getRatingSummary().getReviewCount())
+                : calculateReviewCount(book);
+
+        return new BookSearchDocument(
+                book.getId(),
+                book.getTitle(),
+                book.getSubtitle(),
+                book.getDescription(),
+                book.getPublisher() != null ? book.getPublisher().getName() : null,
+                authors,
+                book.getPublicationDate(),
+                book.getLanguage(),
+                categoryCodes,
+                categoryNames,
+                activePrice != null ? activePrice.getListPrice() : null,
+                activePrice != null ? activePrice.getSalePrice() : null,
+                activePrice != null ? activePrice.getDiscountRate() : null,
+                activeAvailability != null && activeAvailability.getStatus() != null ? activeAvailability.getStatus().name() : null,
+                activeAvailability != null ? activeAvailability.getStockQuantity() : null,
+                averageRating,
+                reviewCount
+        );
+    }
+
+    private BookPrice selectActivePrice(Book book) {
+        OffsetDateTime now = OffsetDateTime.now();
+        return book.getPrices().stream()
+                .filter(price -> price.getEffectiveFrom() != null && !price.getEffectiveFrom().isAfter(now))
+                .filter(price -> price.getEffectiveTo() == null || !price.getEffectiveTo().isBefore(now))
+                .max(Comparator.comparing(BookPrice::getEffectiveFrom))
+                .orElse(null);
+    }
+
+    private BookAvailability selectActiveAvailability(Book book) {
+        OffsetDateTime now = OffsetDateTime.now();
+        return book.getAvailabilities().stream()
+                .filter(availability -> availability.getEffectiveFrom() != null && !availability.getEffectiveFrom().isAfter(now))
+                .filter(availability -> availability.getEffectiveTo() == null || !availability.getEffectiveTo().isBefore(now))
+                .max(Comparator.comparing(BookAvailability::getEffectiveFrom))
+                .orElse(null);
+    }
+
+    private Integer calculateReviewCount(Book book) {
+        long count = book.getReviews().stream()
+                .filter(Objects::nonNull)
+                .map(BookReview::getId)
+                .filter(Objects::nonNull)
+                .count();
+        return (int) count;
+    }
+}

--- a/src/main/java/com/example/bookapi/book/adapter/out/index/BookSearchIndexer.java
+++ b/src/main/java/com/example/bookapi/book/adapter/out/index/BookSearchIndexer.java
@@ -1,0 +1,6 @@
+package com.example.bookapi.book.adapter.out.index;
+
+public interface BookSearchIndexer {
+
+    void index(BookSearchDocument document);
+}

--- a/src/main/java/com/example/bookapi/book/adapter/out/index/BookSearchIndexingEventListener.java
+++ b/src/main/java/com/example/bookapi/book/adapter/out/index/BookSearchIndexingEventListener.java
@@ -1,0 +1,40 @@
+package com.example.bookapi.book.adapter.out.index;
+
+import com.example.bookapi.book.adapter.out.persistence.BookJpaRepository;
+import com.example.bookapi.book.application.event.BookRegisteredEvent;
+import com.example.bookapi.entity.Book;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.event.TransactionPhase;
+
+@Component
+public class BookSearchIndexingEventListener {
+
+    private static final Logger log = LoggerFactory.getLogger(BookSearchIndexingEventListener.class);
+
+    private final BookJpaRepository bookJpaRepository;
+    private final BookSearchDocumentMapper documentMapper;
+    private final BookSearchIndexer bookSearchIndexer;
+
+    public BookSearchIndexingEventListener(BookJpaRepository bookJpaRepository,
+                                           BookSearchDocumentMapper documentMapper,
+                                           BookSearchIndexer bookSearchIndexer) {
+        this.bookJpaRepository = bookJpaRepository;
+        this.documentMapper = documentMapper;
+        this.bookSearchIndexer = bookSearchIndexer;
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(BookRegisteredEvent event) {
+        Optional<Book> book = bookJpaRepository.findById(event.bookId());
+        if (book.isEmpty()) {
+            log.warn("Book with id {} not found for indexing", event.bookId());
+            return;
+        }
+        BookSearchDocument document = documentMapper.map(book.get());
+        bookSearchIndexer.index(document);
+    }
+}

--- a/src/main/java/com/example/bookapi/book/adapter/out/index/OpenSearchBookIndexer.java
+++ b/src/main/java/com/example/bookapi/book/adapter/out/index/OpenSearchBookIndexer.java
@@ -1,0 +1,39 @@
+package com.example.bookapi.book.adapter.out.index;
+
+import com.example.bookapi.config.OpenSearchProperties;
+import java.io.IOException;
+import java.util.Objects;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.core.IndexRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OpenSearchBookIndexer implements BookSearchIndexer {
+
+    private static final Logger log = LoggerFactory.getLogger(OpenSearchBookIndexer.class);
+
+    private final OpenSearchClient client;
+    private final OpenSearchProperties properties;
+
+    public OpenSearchBookIndexer(OpenSearchClient client, OpenSearchProperties properties) {
+        this.client = client;
+        this.properties = properties;
+    }
+
+    @Override
+    public void index(BookSearchDocument document) {
+        try {
+            String documentId = Objects.requireNonNull(document.id(), "Book id must not be null when indexing").toString();
+            IndexRequest<BookSearchDocument> request = IndexRequest.of(builder -> builder
+                    .index(properties.getIndex().getBook())
+                    .id(documentId)
+                    .document(document));
+            client.index(request);
+            log.debug("Indexed book [{}] into OpenSearch", document.id());
+        } catch (IOException e) {
+            throw new BookIndexingException("Failed to index book %s".formatted(document.id()), e);
+        }
+    }
+}

--- a/src/main/java/com/example/bookapi/book/adapter/out/persistence/BookJpaRepository.java
+++ b/src/main/java/com/example/bookapi/book/adapter/out/persistence/BookJpaRepository.java
@@ -1,7 +1,22 @@
 package com.example.bookapi.book.adapter.out.persistence;
 
 import com.example.bookapi.entity.Book;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookJpaRepository extends JpaRepository<Book, Long> {
+
+    @EntityGraph(attributePaths = {
+            "publisher",
+            "authors",
+            "authors.author",
+            "categories",
+            "categories.category",
+            "prices",
+            "availabilities",
+            "assets",
+            "ratingSummary"
+    })
+    Optional<Book> findById(Long id);
 }

--- a/src/main/java/com/example/bookapi/book/application/event/BookRegisteredEvent.java
+++ b/src/main/java/com/example/bookapi/book/application/event/BookRegisteredEvent.java
@@ -1,0 +1,4 @@
+package com.example.bookapi.book.application.event;
+
+public record BookRegisteredEvent(Long bookId) {
+}

--- a/src/main/java/com/example/bookapi/book/application/service/RegisterBookService.java
+++ b/src/main/java/com/example/bookapi/book/application/service/RegisterBookService.java
@@ -1,10 +1,12 @@
 package com.example.bookapi.book.application.service;
 
+import com.example.bookapi.book.application.event.BookRegisteredEvent;
 import com.example.bookapi.book.application.port.in.BookRegistrationResult;
 import com.example.bookapi.book.application.port.in.RegisterBookCommand;
 import com.example.bookapi.book.application.port.in.RegisterBookUseCase;
 import com.example.bookapi.book.application.port.out.SaveBookPort;
 import com.example.bookapi.book.domain.BookRegistration;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,15 +15,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class RegisterBookService implements RegisterBookUseCase {
 
     private final SaveBookPort saveBookPort;
+    private final ApplicationEventPublisher eventPublisher;
 
-    public RegisterBookService(SaveBookPort saveBookPort) {
+    public RegisterBookService(SaveBookPort saveBookPort, ApplicationEventPublisher eventPublisher) {
         this.saveBookPort = saveBookPort;
+        this.eventPublisher = eventPublisher;
     }
 
     @Override
     public BookRegistrationResult register(RegisterBookCommand command) {
         BookRegistration registration = command.toBookRegistration();
         Long bookId = saveBookPort.save(registration);
+        eventPublisher.publishEvent(new BookRegisteredEvent(bookId));
         return new BookRegistrationResult(bookId);
     }
 }

--- a/src/main/java/com/example/bookapi/config/OpenSearchConfig.java
+++ b/src/main/java/com/example/bookapi/config/OpenSearchConfig.java
@@ -1,0 +1,42 @@
+package com.example.bookapi.config;
+
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
+import org.apache.http.HttpHost;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.RestClientBuilder;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.transport.rest_client.RestClientTransport;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(OpenSearchProperties.class)
+public class OpenSearchConfig {
+
+    @Bean
+    public RestClientBuilder restClientBuilder(OpenSearchProperties properties) {
+        RestClientBuilder builder = RestClient.builder(new HttpHost(properties.getHost(), properties.getPort(), properties.getScheme()));
+        if (properties.getUsername() != null && !properties.getUsername().isBlank()) {
+            BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            credentialsProvider.setCredentials(AuthScope.ANY,
+                    new UsernamePasswordCredentials(properties.getUsername(), properties.getPassword()));
+            builder.setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
+        }
+        return builder;
+    }
+
+    @Bean(destroyMethod = "close")
+    public RestClient restClient(RestClientBuilder builder) {
+        return builder.build();
+    }
+
+    @Bean
+    public OpenSearchClient openSearchClient(RestClient restClient) {
+        RestClientTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
+        return new OpenSearchClient(transport);
+    }
+}

--- a/src/main/java/com/example/bookapi/config/OpenSearchProperties.java
+++ b/src/main/java/com/example/bookapi/config/OpenSearchProperties.java
@@ -1,0 +1,71 @@
+package com.example.bookapi.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "opensearch")
+public class OpenSearchProperties {
+
+    private String host;
+    private int port;
+    private String scheme = "http";
+    private String username;
+    private String password;
+    private final Index index = new Index();
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public String getScheme() {
+        return scheme;
+    }
+
+    public void setScheme(String scheme) {
+        this.scheme = scheme;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public Index getIndex() {
+        return index;
+    }
+
+    public static class Index {
+
+        private String book = "books";
+
+        public String getBook() {
+            return book;
+        }
+
+        public void setBook(String book) {
+            this.book = book;
+        }
+    }
+}

--- a/src/main/java/com/example/bookapi/entity/Author.java
+++ b/src/main/java/com/example/bookapi/entity/Author.java
@@ -22,9 +22,6 @@ public class Author extends AuditableEntity {
     @Column(nullable = false, length = 200)
     private String name;
 
-    @Column(name = "name_kana", length = 200)
-    private String nameKana;
-
     @Column(columnDefinition = "TEXT")
     private String description;
 
@@ -51,14 +48,6 @@ public class Author extends AuditableEntity {
 
     public void setName(String name) {
         this.name = name;
-    }
-
-    public String getNameKana() {
-        return nameKana;
-    }
-
-    public void setNameKana(String nameKana) {
-        this.nameKana = nameKana;
     }
 
     public String getDescription() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,13 @@ spring:
 server:
   port: 8080
 
+opensearch:
+  host: localhost
+  port: 9200
+  scheme: http
+  index:
+    book: books
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
## Summary
- add OpenSearch client configuration and properties for connecting to a Docker-hosted cluster
- publish a post-commit BookRegisteredEvent and handle it to build and index search documents
- remove unused Japanese-specific author kana column and document OpenSearch usage in the README

## Testing
- ⚠️ `gradle test` *(fails: dependency downloads blocked with HTTP 403 responses in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcb69bf7f08323b4c1b669c59d8a61